### PR TITLE
Added a string function to Receipt `normalize()`

### DIFF
--- a/receipt_parser_core/receipt.py
+++ b/receipt_parser_core/receipt.py
@@ -52,7 +52,7 @@ class Receipt(object):
         """
 
         self.lines = [
-            line.lower() for line in self.lines if line.strip()
+            line.lower() for line in self.lines.splitlines() if line.strip()
         ]
 
     def parse(self):


### PR DESCRIPTION
I found that the `parse()` function wouldn't return anything because Receipt's `self.lines` ended up being a list of individual characters.
Adding `.splitlines()` to `normalize()` changes the list `self.lines` to more accurately represent a list of lines of the text file, separated by newlines.